### PR TITLE
Simplify shim structure, build from Rust source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 elf = "0.7.4"
 object = { version = "0.36.5", default-features = false, features = ["elf", "write_std"] }
+
+[build-dependencies]
+elf = "0.7.4"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,59 @@
+use elf::{abi::*, endian::AnyEndian, ElfBytes};
+use std::{env, process::Command};
+
+const TARGETS: &[&str] = &["x86_64-unknown-none"];
+
+const DT_RELR: i64 = 36;
+
+fn segment_data(path: &str) -> Vec<u8> {
+    let bytes = std::fs::read(path).expect("Reading file");
+    let elf: ElfBytes<AnyEndian> = ElfBytes::minimal_parse(&bytes).expect("Parsing file");
+    let dynamic = elf
+        .dynamic()
+        .expect("Parsing dynamic segment")
+        .expect("File should have dynamic segment");
+
+    assert!(
+        !dynamic
+            .iter()
+            .any(|d| [DT_REL, DT_RELA, DT_RELR].contains(&d.d_tag)),
+        "Shim should have no relocations"
+    );
+    let segments = elf.segments().expect("Parsing segments");
+    let seg = segments.get(0).expect("Get first segment");
+    assert!(seg.p_type == PT_LOAD, "First segment should be PT_LOAD");
+    let data = elf.segment_data(&seg).expect("Getting segment data");
+    data.to_vec()
+}
+
+fn main() {
+    println!("cargo::rerun-if-changed=shim");
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let call_rustc = |target| {
+        let status = Command::new("rustc")
+            .arg(format!("--target={target}"))
+            .arg("-Copt-level=s")
+            .arg("-Cpanic=abort")
+            .arg("-Crelocation-model=pic")
+            .arg("-Clink-args=-pie")
+            .arg("-Clink-args=-Tshim/link.x")
+            .arg(format!("--out-dir={out_dir}/shim/{target}"))
+            .arg("--crate-name=shim")
+            .arg("shim/main.rs")
+            .env("RUSTC_BOOTSTRAP", "1")
+            .status()
+            .unwrap();
+        assert!(status.success());
+    };
+
+    for target in TARGETS {
+        call_rustc(target);
+        let elf_file = format!("{out_dir}/shim/{target}/shim");
+        eprintln!("Building {elf_file}");
+        let data = segment_data(&elf_file);
+        eprintln!("Processing {elf_file}");
+        let out_path = format!("{out_dir}/shim/{target}/shim.bin");
+        std::fs::write(out_path, data).expect("Writing segment data");
+    }
+}

--- a/shim/link.x
+++ b/shim/link.x
@@ -1,0 +1,19 @@
+ENTRY(_start)
+
+PHDRS {
+    load PT_LOAD;
+    dynamic PT_DYNAMIC;
+}
+
+SECTIONS {
+    shim_base = .;
+    .text : {
+        *(.text.entry)
+        *(.text .text.*)
+        *(.rodata .rodata.*)
+        . = ALIGN(8);
+    } : load
+    shim_data = .;
+    .dynamic : { *(.dynamic) } : dynamic
+    /DISCARD/ : { *(.dynsym .gnu.hash .hash .dynstr) }
+}

--- a/shim/main.rs
+++ b/shim/main.rs
@@ -1,0 +1,150 @@
+#![feature(auto_traits)]
+#![feature(decl_macro)]
+#![feature(intrinsics)]
+#![feature(lang_items)]
+#![feature(no_core)]
+#![feature(rustc_attrs)]
+#![allow(internal_features)]
+#![no_core]
+#![no_std]
+#![no_main]
+#![no_builtins]
+
+#[repr(C)]
+struct ShimData {
+    user_entry_rel: usize,
+    interp_entry_rel: usize,
+    interp_base_rel: usize,
+    interp_phnum: usize,
+}
+
+#[repr(C)]
+struct Auxv {
+    tag: usize,
+    value: usize,
+}
+
+const AT_BASE: usize = 0x7;
+const AT_ENTRY: usize = 0x9;
+const AT_PHNUM: usize = 0x5;
+
+unsafe fn find_auxv(mut stack: *mut usize) -> *mut Auxv {
+    let argc = *stack;
+
+    // Skip argc, arguments, terminating NULL
+    stack = offset(stack, wrapping_add(argc, 2));
+
+    // Skip environment
+    while *stack != 0 {
+        stack = offset(stack, 1);
+    }
+
+    // Skip terminating NULL
+    stack = offset(stack, 1);
+
+    stack as _
+}
+
+#[no_mangle] // Make disassembly slightly easier to read
+#[deny(dead_code, reason = "If you see this it means the architecture is unsupported")]
+unsafe extern "C" fn shim_main(stack: *mut usize, data: &ShimData, base: usize) -> usize {
+    let mut auxv = find_auxv(stack);
+
+    loop {
+        let a: &mut Auxv = &mut *auxv;
+        auxv = offset(auxv, 1);
+
+        match a.tag {
+            0 => break,
+            AT_BASE => a.value = wrapping_add(data.interp_base_rel, base),
+            AT_ENTRY => a.value = wrapping_add(data.user_entry_rel, base),
+            AT_PHNUM => a.value = data.interp_phnum,
+            _ => {}
+        }
+    }
+
+    wrapping_add(data.interp_entry_rel, base)
+}
+
+#[cfg(target_arch = "x86_64")]
+global_asm!(
+    r#"
+    .pushsection .text.entry
+
+    .global _start
+_start:
+    mov rbp, rsp // Save initial stack pointer
+
+    // Args for shim_main
+    mov rdi, rsp
+    lea rsi, [rip + shim_data]
+    lea rdx, [rip + shim_base]
+
+    and rsp, -16 // Align stack for function call
+    call {shim_main}
+
+    mov rsp, rbp // Restore stack
+    jmp rax // Jump to interp_entry
+
+    .popsection
+    "#,
+    shim_main = sym shim_main
+);
+
+// >>> Here be dragons <<<
+
+mod intrinsic {
+    use super::*;
+
+    extern "rust-intrinsic" {
+        #[rustc_safe_intrinsic]
+        #[rustc_nounwind]
+        pub(super) fn wrapping_add<T: Copy>(a: T, b: T) -> T;
+
+        #[rustc_nounwind]
+        pub(super) fn offset<Ptr, Delta>(dst: Ptr, offset: Delta) -> Ptr;
+    }
+}
+
+unsafe fn offset<T>(dst: *mut T, offset: usize) -> *mut T {
+    intrinsic::offset(dst, offset)
+}
+
+fn wrapping_add(a: usize, b: usize) -> usize {
+    intrinsic::wrapping_add(a, b)
+}
+
+#[rustc_builtin_macro]
+pub macro global_asm() {}
+
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "receiver"]
+trait Receiver {}
+impl<T: ?Sized> Receiver for &T {}
+
+#[lang = "freeze"]
+auto trait Freeze {}
+
+#[lang = "copy"]
+trait Copy {}
+impl<T> Copy for *mut T {}
+impl Copy for usize {}
+impl Copy for bool {}
+
+#[allow(dead_code)] // Spurious
+#[lang = "eq"]
+trait PartialEq<Rhs: ?Sized = Self> {
+    fn eq(&self, other: &Rhs) -> bool;
+    fn ne(&self, other: &Rhs) -> bool;
+}
+
+impl PartialEq for usize {
+    fn eq(&self, other: &usize) -> bool {
+        *self == *other
+    }
+    fn ne(&self, other: &usize) -> bool {
+        *self != *other
+    }
+}

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -28,42 +28,36 @@ fn make_shim(
     // to AT_BASE (which *must* point to the `\x7FELF` of the interpreter) and AT_ENTRY (which must point to
     // the PIE entry point). Since we interpose this shim using the `e_entry` file header field, we must restore
     // the original `e_entry` by modifying `AT_ENTRY`.
-    if machine == EM_X86_64 {
-        let i1 = interp_entry as i64 - (base as i64 + 30);
-        let i2 =  interp_base as i64 - (base as i64 + 43);
-        let i3 =   user_entry as i64 - (base as i64 + 60);
-        let i4 = interp_phdrs as u8;
-        let mut code = vec![
-            0x48, 0x8b, 0x3c, 0x24,
-            0x48, 0x8d, 0x7c, 0xfc, 0x10,
+    //
+    // The shim consists of a code part (blob built from shim/ in build.rs and included) and data part (built here).
+    // The code part must be completely position independent (no relocations) and padding to align the data part
+    // must be included in the blob. The code part reads the data part using pc-relative addresses.
 
-            0x48, 0x83, 0x3f, 0x00,
-            0x48, 0x8d, 0x7f, 0x08,
-            0x75, 0xf6,
+    macro_rules! shim_blob {
+        ($target:expr) => {
+            include_bytes!(concat!(env!("OUT_DIR"), "/shim/", $target, "/shim.bin"))
+        };
+    }
 
-            0x48, 0x83, 0x3f, 0x00,
-            0x75, 0x05,
-            0xe9, (i1&0xff) as u8, (i1>>8) as u8, (i1>>16) as u8, (i1>>24) as u8,
-
-            0x48, 0x83, 0x3f, 0x07, 0x75, 0x0b, // AT_BASE  = 0x7
-            0x48, 0x8d, 0x35, (i2&0xff) as u8, (i2>>8) as u8, (i2>>16) as u8, (i2>>24) as u8,
-            0x48, 0x89, 0x77, 0x08,
-
-            0x48, 0x83, 0x3f, 0x09, 0x75, 0x0b, // AT_ENTRY = 0x9
-            0x48, 0x8d, 0x35, (i3&0xff) as u8, (i3>>8) as u8, (i3>>16) as u8, (i3>>24) as u8,
-            0x48, 0x89, 0x77, 0x08,
-
-            0x48, 0x83, 0x3f, 0x05, 0x75, 0x05, // AT_PHNUM = 0x5
-            0x48, 0x83, 0x6f, 0x08, i4,
-
-            0x48, 0x83, 0xc7, 0x10,
-            0xeb, 0xc2,
-        ];
-        code.resize(((code.len() - 1) | 0xff) + 1, 0); // pad to make it easier to edit in binja
-        code
+    let code = if machine == EM_X86_64 {
+        shim_blob!("x86_64-unknown-none").to_vec()
     } else {
         panic!("Shim not implemented for machine: {:?}", machine)
-    }
+    };
+
+    let mut code = code.to_vec();
+
+    // Append data part of shim
+
+    // Keep in sync with shim/main.rs
+    // TODO: Handle 32-bit stuff
+    code.extend(user_entry.wrapping_sub(base).to_le_bytes());
+    code.extend(interp_entry.wrapping_sub(base).to_le_bytes());
+    code.extend(interp_base.wrapping_sub(base).to_le_bytes());
+    code.extend((interp_phdrs as u64).to_le_bytes());
+
+    code.resize(((code.len() - 1) | 0xff) + 1, 0); // pad to make it easier to edit in binja
+    code
 }
 
 pub fn emit_elf(image: &Image) -> object::write::Result<Vec<u8>> {


### PR DESCRIPTION
(Retake of #2)

The shim is now two parts, code and data. See code comments for details.

Also we build the shim from Rust code. Unfortunately some assembly code
is still required as the ELF entrypoint does not work like a C function,
but it should be much more readable and portable than the original blob
of bytes.

To avoid having to ask the user to install more targets, the shim is
written as a `#![no_core]` executable. Fingers crossed this never gets
unfixably broken.
